### PR TITLE
quickstart notebook build index fix

### DIFF
--- a/notebooks/Quickstart.ipynb
+++ b/notebooks/Quickstart.ipynb
@@ -259,7 +259,7 @@
     "        \"storage_name\": storage_name,\n",
     "        \"index_name\": index_name\n",
     "    }\n",
-    "    return requests.post(url, json=request, headers=headers)"
+    "    return requests.post(url, params=request, headers=headers)"
    ]
   },
   {


### PR DESCRIPTION
updated build index method to use parameters instead of JSON payload for request