### PR TITLE
Increase AKS probe settings

### DIFF
--- a/infra/helm/graphrag/values.yaml
+++ b/infra/helm/graphrag/values.yaml
@@ -82,15 +82,17 @@ query:
     httpGet:
       path: /manpage/docs
       port: http
+    failureThreshold: 50
     initialDelaySeconds: 30
-    periodSeconds: 10
+    periodSeconds: 20
 
   readinessProbe:
     httpGet:
       path: /manpage/docs
       port: http
+    failureThreshold: 50
     initialDelaySeconds: 30
-    periodSeconds: 10
+    periodSeconds: 20
 
   autoscaling:
     enabled: true
@@ -167,15 +169,17 @@ index:
     httpGet:
       path: /manpage/docs
       port: http
+    failureThreshold: 50
     initialDelaySeconds: 30
-    periodSeconds: 10
+    periodSeconds: 20
 
   readinessProbe:
     httpGet:
       path: /manpage/docs
       port: http
+    failureThreshold: 50
     initialDelaySeconds: 30
-    periodSeconds: 10
+    periodSeconds: 20
 
   autoscaling:
     enabled: true


### PR DESCRIPTION
This fix avoids a known async vs synchronous issue with the template generation API endpoint.