### PR TITLE
Update deploy.sh

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -513,18 +513,18 @@ createAcrIfNotExists() {
     local existingRegistry
     existingRegistry=$(az acr show --name $CONTAINER_REGISTRY_SERVER --query loginServer -o tsv 2>/dev/null)
     if [ $? -eq 0 ]; then
-        printf "Yes. Using existing registry '$existingRegistry'.\n"
+        printf "Yes.\nUsing existing registry '$existingRegistry'.\n"
         CONTAINER_REGISTRY_SERVER=$existingRegistry
         return 0
     fi
     # else deploy a new container registry
-    printf "Creating container registry... "
+    printf "No.\nCreating container registry... "
     AZURE_ACR_DEPLOY_RESULT=$(az deployment group create --resource-group $RESOURCE_GROUP --name "acr-deployment" --template-file core/acr/acr.bicep --only-show-errors --no-prompt -o json \
         --parameters "name=$CONTAINER_REGISTRY_SERVER")
     exitIfCommandFailed $? "Error creating container registry, exiting..."
     CONTAINER_REGISTRY_SERVER=$(jq -r .properties.outputs.loginServer.value <<< $AZURE_ACR_DEPLOY_RESULT)
     exitIfValueEmpty "$CONTAINER_REGISTRY_SERVER" "Unable to parse container registry login server from deployment, exiting..."
-    printf "container registry '$CONTAINER_REGISTRY_SERVER' created.\n"
+    printf "'$CONTAINER_REGISTRY_SERVER' created.\n"
 }
 
 deployDockerImageToACR() {

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -509,11 +509,12 @@ grantDevAccessToAzureResources() {
 
 createAcrIfNotExists() {
     # check if container registry exists
-    if [ ! -z "$CONTAINER_REGISTRY_SERVER" ]; then
-        printf "Checking if container registry '$CONTAINER_REGISTRY_SERVER' exists... "
-        az acr show --name $CONTAINER_REGISTRY_SERVER > /dev/null 2>&1
-        exitIfCommandFailed $? "Container registry '$CONTAINER_REGISTRY_SERVER' not found, exiting..."
-        printf "Yes.\n"
+    printf "Checking if container registry exists... "
+    local existingRegistry
+    existingRegistry=$(az acr show --name $CONTAINER_REGISTRY_SERVER --query loginServer -o tsv 2>/dev/null)
+    if [ $? -eq 0 ]; then
+        printf "Yes. Using existing registry '$existingRegistry'.\n"
+        CONTAINER_REGISTRY_SERVER=$existingRegistry
         return 0
     fi
     # else deploy a new container registry


### PR DESCRIPTION
## [BUG] ACR Autocreate may not actually test if ACR already exists #43

### Issue
- **Problem**: After a Bash session reset, `CONTAINER_REGISTRY_SERVER` might not be set, causing incorrect logging about creating a new ACR.
- **Steps to Reproduce**:
  1. Run `deploy.sh` to create an ACR.
  2. Reset the Bash session or unset `CONTAINER_REGISTRY_SERVER`.
  3. Run `deploy.sh` again; it incorrectly logs creating a new ACR.

### Expected Behavior
The script should check if an ACR exists and log correctly.

### Fix
Updated `createAcrIfNotExists()` to always check for an existing ACR and log appropriately.

### Updated Function

```bash
createAcrIfNotExists() {
    printf "Checking if container registry exists... "
    local existingRegistry
    existingRegistry=$(az acr show --name $CONTAINER_REGISTRY_SERVER --query loginServer -o tsv 2>/dev/null)
    if [ $? -eq 0 ]; then
        printf "Yes. Using existing registry '$existingRegistry'.\n"
        CONTAINER_REGISTRY_SERVER=$existingRegistry
        return 0
    fi

    printf "No. Creating container registry... "
    AZURE_ACR_DEPLOY_RESULT=$(az deployment group create --resource-group $RESOURCE_GROUP --name "acr-deployment" --template-file core/acr/acr.bicep --only-show-errors --no-prompt -o json \
        --parameters "name=$CONTAINER_REGISTRY_SERVER")
    exitIfCommandFailed $? "Error creating container registry, exiting..."
    CONTAINER_REGISTRY_SERVER=$(jq -r .properties.outputs.loginServer.value <<< $AZURE_ACR_DEPLOY_RESULT)
    exitIfValueEmpty "$CONTAINER_REGISTRY_SERVER" "Unable to parse container registry login server from deployment, exiting..."
    printf "Container registry '$CONTAINER_REGISTRY_SERVER' created.\n"
}
```

### Summary
- **Always Checks**: Now always checks if the ACR exists.
- **Correct Logging**: Logs whether it found an existing ACR or created a new one.

This fix ensures accurate logging and proper handling of the ACR status across sessions. Thanks for your contribution!