### PR TITLE
Update .gitattributes to force LF, even on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # all files are checked into the repo with LF
-* text=auto
+* text eol=lf


### PR DESCRIPTION
Since users are expected to run from a dev container, this prevents line ending conversion.

Verified on:
* Windows using Git from Visual Studio
* Ubuntu (WSL2)

