### PR TITLE
Add option to use existing ingress controller

### DIFF
--- a/infra/helm/graphrag/templates/graphrag-nginx-internal-controller.yaml
+++ b/infra/helm/graphrag/templates/graphrag-nginx-internal-controller.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.createIngressClass -}}
 apiVersion: approuting.kubernetes.azure.com/v1alpha1
 kind: NginxIngressController
 metadata:
@@ -9,3 +10,4 @@ spec:
   loadBalancerAnnotations:
     {{- toYaml . | nindent 4 }}
   {{- end }} 
+{{- end }}

--- a/infra/helm/graphrag/values.yaml
+++ b/infra/helm/graphrag/values.yaml
@@ -18,6 +18,7 @@ serviceAccount:
 ingress:
   enabled: true
   className: nginx-internal
+  createIngressClass: true
   host: graphrag.graphrag.io
   tls: []
   annotations:


### PR DESCRIPTION
When including GraphRAG in a larger helm deployment that already has an ingress controller I would like to be able to disable creating the GraphRAG ingress controller class, and instead use the name of the existing ingress controller.