### PR TITLE
Disable the local admin on the ACR

### DIFF
--- a/infra/core/acr/acr.bicep
+++ b/infra/core/acr/acr.bicep
@@ -14,7 +14,7 @@ resource registry 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = 
     name: 'Standard'
   }
   properties: {
-    adminUserEnabled: true
+    adminUserEnabled: false
     encryption: {
       status: 'disabled'
     }


### PR DESCRIPTION
Disabling the local admin user login on the ACR.. This fixes the violation of the policy on tenants about not use the local account logins