### PR TITLE
Update path of venv 

### DIFF
--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -10,9 +10,16 @@ sudo chmod 666 /var/run/docker.sock
 ################################
 
 # Install graphrag dependencies
+# NOTE: temporarily copy the pyproject.toml and poetry.lock files to the root directory to install dependencies.
+# This avoids having a .venv folder in the backend directory, which causes PATH issues when building the
+# backend docker image during deployment
 ROOT_DIR=/graphrag-accelerator
 cd ${ROOT_DIR}
-poetry install --no-interaction -v --directory ${ROOT_DIR}/backend
+cp ${ROOT_DIR}/backend/pyproject.toml ${ROOT_DIR}
+cp ${ROOT_DIR}/backend/poetry.lock ${ROOT_DIR}
+poetry install --no-interaction -v
+rm ${ROOT_DIR}/pyproject.toml
+rm ${ROOT_DIR}/poetry.lock
 
 #########################
 ### Git configuration ###


### PR DESCRIPTION
This PR fixes the installation path, inside a devcontainer, of the venv environment when used with poetry. A `.venv` folder in the backend directory was causing PATH issues while building the backend docker image at deployment time.