### PR TITLE
Fix overlapping CIDR block

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,8 +19,9 @@
 		"PATH": "${containerEnv:PATH}",
 		// Add src folder to PYTHONPATH so that we can import modules that
 		// are in the source dir
-		"PYTHONPATH": "/graphrag-accelerator/backend/:$PATH",
-		"AZURE_CLI_DISABLE_CONNECTION_VERIFICATION": "1"
+		"PYTHONPATH": "/graphrag-accelerator/backend/:$PATH"
+		// disable SSL verification for Azure CLI if working in CodeSpaces
+		// "AZURE_CLI_DISABLE_CONNECTION_VERIFICATION": "1"
 	},
 	"mounts": [
 		// NOTE: we reference both HOME and USERPROFILE environment variables to simultaneously support both Windows and Unix environments

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,12 +2,12 @@ notebooks
 
 # Environments
 .env
-.venv
 env/
-venv/
 ENV/
-env.bak/
-venv.bak/
+**/env.bak
+**/venv.bak
+**/.venv
+**/venv
 
 .github
 .git

--- a/docker/Dockerfile-backend
+++ b/docker/Dockerfile-backend
@@ -18,7 +18,7 @@ RUN cd backend \
     && poetry install
 
 # download all nltk data that graphrag requires
-RUN python -m nltk.downloader punkt averaged_perceptron_tagger maxent_ne_chunker words wordnet
+RUN python -c "import nltk;nltk.download(['punkt','averaged_perceptron_tagger','maxent_ne_chunker','words','wordnet'])"
 
 WORKDIR /backend
 EXPOSE 80

--- a/infra/core/aks/aks.bicep
+++ b/infra/core/aks/aks.bicep
@@ -132,8 +132,9 @@ resource aks 'Microsoft.ContainerService/managedClusters@2024-02-01' = {
       }
     }
     networkProfile: {
-      serviceCidr: '10.2.0.0/16'
-      dnsServiceIP: '10.2.0.10'
+      serviceCidr: '10.3.0.0/16'  // must not overlap with any subnet IP ranges
+      dnsServiceIP: '10.3.0.10'   // must be within the range specified in serviceCidr
+      podCidr: '10.244.0.0/16'    // IP range from which to assign pod IPs
     }
     autoUpgradeProfile: autoUpgradeProfile
     oidcIssuerProfile: {

--- a/infra/core/cosmosdb/cosmosdb.bicep
+++ b/infra/core/cosmosdb/cosmosdb.bicep
@@ -89,45 +89,6 @@ resource graphragDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@20
   }
 }
 
-//// comment out entitiesContainer resource as the set of entity configuration API endpoints that use this have been disabled for now
-// resource entitiesContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2022-11-15' = {
-//   parent: graphragDatabase
-//   name: 'entities'
-//   properties: {
-//     resource: {
-//       id: 'entities'
-//       indexingPolicy: {
-//         indexingMode: 'consistent'
-//         automatic: true
-//         includedPaths: [
-//           {
-//             path: '/*'
-//           }
-//         ]
-//         excludedPaths: [
-//           {
-//             path: '/"_etag"/?'
-//           }
-//         ]
-//       }
-//       partitionKey: {
-//         paths: [
-//           '/id'
-//         ]
-//         kind: 'Hash'
-//         version: 2
-//       }
-//       uniqueKeyPolicy: {
-//         uniqueKeys: []
-//       }
-//       conflictResolutionPolicy: {
-//         mode: 'LastWriterWins'
-//         conflictResolutionPath: '/_ts'
-//       }
-//     }
-//   }
-// }
-
 resource jobsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2022-11-15' = {
   parent: graphragDatabase
   name: 'jobs'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -127,14 +127,14 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
   properties: {
     addressSpace: {
       addressPrefixes: [
-        '10.0.0.0/8'
+        '10.1.0.0/16'
       ]
     }
     subnets: [
       {
         name: '${abbrs.networkVirtualNetworksSubnets}apim'
         properties: {
-          addressPrefix: '10.0.0.0/16'
+          addressPrefix: '10.1.0.0/24'
           networkSecurityGroup: {
             id: nsg.outputs.id
           }
@@ -151,7 +151,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-01-01' = {
       {
         name: '${abbrs.networkVirtualNetworksSubnets}aks'
         properties: {
-          addressPrefix: '10.1.0.0/16'
+          addressPrefix: '10.1.1.0/24'
           serviceEndpoints: [
             {
               service: 'Microsoft.Storage'


### PR DESCRIPTION
This PR resolves a recent issue that shows up during the deployment process. During the aks deployment, Azure reports back an error regarding the overlap of some hardcoded CIDR blocks of IP ranges.