### PR TITLE
Add private dns zone names for Azure Government AI Search and CosmosDB - Fixes #71

### DIFF
--- a/infra/core/vnet/private-dns-zone-groups.json
+++ b/infra/core/vnet/private-dns-zone-groups.json
@@ -1,18 +1,22 @@
 {
   "azureCloud": {
+    "aiSearch": "privatelink.search.azure.com",
     "azureMonitor": [
       "privatelink.monitor.azure.com",
       "privatelink.oms.opinsights.azure.com",
       "privatelink.agentsvc.azure-automation.net",
       "privatelink.ods.opinsights.azure.com"
-    ]
+    ],
+    "cosmosDB": "privatelink.documents.azure.com"
   },
   "azureusgovernment": {
+    "aiSearch": "privatelink.search.azure.us",
     "azureMonitor": [
       "privatelink.monitor.azure.us",
       "privatelink.oms.opinsights.azure.us",
       "privatelink.agentsvc.azure-automation.us",
       "privatelink.ods.opinsights.azure.us"
-    ]
+    ],
+    "cosmosDB": "privatelink.documents.azure.us"
   }
 }

--- a/infra/core/vnet/privatelink-private-dns-zones.bicep
+++ b/infra/core/vnet/privatelink-private-dns-zones.bicep
@@ -4,13 +4,15 @@
 @description('Virtual Network IDs to link to')
 param linkedVnetIds array
 
-var aiSearchPrivateDnsZoneName = 'privatelink.search.windows.net'
-var blobStoragePrivateDnsZoneName = 'privatelink.blob.${environment().suffixes.storage}'
-var cosmosDbPrivateDnsZoneName = 'privatelink.documents.azure.com'
-var storagePrivateDnsZoneNames = [blobStoragePrivateDnsZoneName]
 var privateDnsZoneData = loadJsonContent('private-dns-zone-groups.json')
 var cloudName = toLower(environment().name)
+
+var aiSearchPrivateDnsZoneName = privateDnsZoneData[cloudName].aiSearch
+var blobStoragePrivateDnsZoneName = 'privatelink.blob.${environment().suffixes.storage}'
+var cosmosDbPrivateDnsZoneName = privateDnsZoneData[cloudName].cosmosDb
+var storagePrivateDnsZoneNames = [blobStoragePrivateDnsZoneName]
 var azureMonitorPrivateDnsZones = privateDnsZoneData[cloudName].azureMonitor
+
 var privateDnsZones = union(
   azureMonitorPrivateDnsZones,
   storagePrivateDnsZoneNames,


### PR DESCRIPTION
While testing a default (secure) deployment of GraphRAG in Azure Government, I noticed that #71 still seemed to be a problem.

It finally occurred to me that it looked like the graphrag container was trying to hit CosmosDB over the public internet rather than using the private networking that is in place. After a bit of digging, I noticed that the Private DNS Zone names for CosmosDB and AI Search were not correct for Azure Government.

This PR:
- Adds the proper Private DNS Zone names for CosmosDB and AI Search in Azure Government to the `private-dns-zone-groups.json` file
- Updates the `privatelink-private-dns-zones.bicep` file to use those names.